### PR TITLE
Update ngx_http_upstream_check_module.c

### DIFF
--- a/ngx_http_upstream_check_module.c
+++ b/ngx_http_upstream_check_module.c
@@ -52,7 +52,7 @@ typedef struct {
     u_char                                   type;
 } ngx_ajp_raw_packet_t;
 
-#pragma pack()
+#pragma pack(pop)
 
 
 typedef struct {


### PR DESCRIPTION
Fix for these 2 warnings:
../nginx_upstream_check_module/ngx_http_upstream_check_module.c:16:9: warning: unterminated '#pragma pack (push, ...)' at end of file [-Wpragma-pack]
#pragma pack(push, 1)
        ^
../nginx_upstream_check_module/ngx_http_upstream_check_module.c:55:9: note: did you intend to use '#pragma pack (pop)' instead of '#pragma pack()'?
#pragma pack()
        ^